### PR TITLE
Fix serde attribute in leptos-otp example

### DIFF
--- a/examples/leptos-oauth/src/main.rs
+++ b/examples/leptos-oauth/src/main.rs
@@ -5,8 +5,8 @@ use wasm_bindgen::{prelude::Closure, JsValue};
 use web_sys::console::log_1;
 
 #[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Options {
-    #[serde(rename = "camelCase")]
     pub redirect_to: String,
 }
 


### PR DESCRIPTION
Changing the derive attribute to instead use `#[serde(rename_all = "camelCase")]` on the struct made the redirect work for me, whereas it wasn't working before the change.

Also, thanks for making this repo! It's been very helpful.